### PR TITLE
Fix Hifi Decode UI sample rate selection

### DIFF
--- a/vhsdecode/hifi/HifiUi.py
+++ b/vhsdecode/hifi/HifiUi.py
@@ -171,7 +171,7 @@ class InputDialog(QDialog):
 
     def get_input_value(self):
         result = self.exec()  # Ejecutar el diálogo de entrada
-        if result == QDialog.Accepted:
+        if result == QDialog.accepted:
             return self.input_line.text()
         else:
             return None


### PR DESCRIPTION
Fix a bug where the Hifi Decode UI crashes when selecting a custom sample rate.

```
Input sample rate changed.
Traceback (most recent call last):
  File "/home/ethan/.local/pipx/venvs/vhs-decode/lib/python3.10/site-packages/vhsdecode/hifi/HifiUi.py", line 582, in on_input_samplerate_changed
    value: float = input_dialog.get_input_value()
  File "/home/ethan/.local/pipx/venvs/vhs-decode/lib/python3.10/site-packages/vhsdecode/hifi/HifiUi.py", line 174, in get_input_value
    if result == QDialog.Accepted:
AttributeError: type object 'QDialog' has no attribute 'Accepted'. Did you mean: 'accepted'?
Aborted (core dumped)
```